### PR TITLE
⚡ Optimize Signature Service scheduleReminders to avoid N+1 queries

### DIFF
--- a/backend/src/services/signature.service.js
+++ b/backend/src/services/signature.service.js
@@ -673,21 +673,20 @@ async function sendForSignature(pool, emailService, documentId, organizationId, 
 
 async function scheduleReminders(pool, documentId, daysFromNow = 2) {
     return withTransaction(pool, async (client) => {
-        const recipientsResult = await client.query(
-            'SELECT id FROM signature_recipients WHERE document_id = $1 AND status IN (\'pending\', \'sent\', \'viewed\')',
-            [documentId]
-        );
         const scheduledAt = new Date(Date.now() + daysFromNow * 24 * 60 * 60 * 1000);
-        for (const recipient of recipientsResult.rows) {
-            await client.query(`
-                INSERT INTO signature_reminders (document_id, recipient_id, scheduled_at, status)
-                VALUES ($1, $2, $3, 'pending')
-            `, [documentId, recipient.id, scheduledAt]);
-        }
+
+        await client.query(`
+            INSERT INTO signature_reminders (document_id, recipient_id, scheduled_at, status)
+            SELECT document_id, id, $1, 'pending'
+            FROM signature_recipients
+            WHERE document_id = $2 AND status IN ('pending', 'sent', 'viewed')
+        `, [scheduledAt, documentId]);
+
         await client.query(`
             INSERT INTO signature_audit_log (document_id, event_type, description, created_at)
             VALUES ($1, 'reminder_scheduled', 'Signature reminders scheduled', CURRENT_TIMESTAMP)
         `, [documentId]);
+
         return { scheduledAt };
     });
 }


### PR DESCRIPTION
💡 **What:** Refactored the \`scheduleReminders\` function in \`SignatureService\` to use a single \`INSERT INTO ... SELECT\` statement instead of a \`SELECT\` followed by a loop of individual \`INSERT\` queries.

🎯 **Why:** This solves an N+1 query problem where a separate database call was made for each recipient to schedule a reminder. For documents with many recipients, this significantly reduces database round-trips and improves performance.

📊 **Measured Improvement:** In a mock environment with 100 recipients, the number of \`INSERT\` queries was reduced from 100 to 1. The total number of database calls for the transaction was reduced from N+2 (102) to 2.

---
*PR created automatically by Jules for task [16273316987649579951](https://jules.google.com/task/16273316987649579951) started by @codebymv*