### PR TITLE
⚡ perf: optimize replaceTemplateFields to use bulk insert

### DIFF
--- a/backend/src/services/signature.service.js
+++ b/backend/src/services/signature.service.js
@@ -1230,30 +1230,18 @@ async function replaceTemplateRoles(pool, templateId, roles) {
 async function replaceTemplateFields(pool, templateId, fields) {
     return withTransaction(pool, async (client) => {
         await client.query('DELETE FROM signature_template_fields WHERE template_id = $1', [templateId]);
-        const inserted = [];
+
+        if (!fields || fields.length === 0) {
+            return [];
+        }
+
+        const values = [];
+        const flatValues = [];
+        let paramIndex = 1;
+
         for (const field of fields) {
-            const result = await client.query(`
-                INSERT INTO signature_template_fields (
-                    template_id,
-                    role_name,
-                    field_type,
-                    page_number,
-                    x_position,
-                    y_position,
-                    width,
-                    height,
-                    label,
-                    is_required,
-                    font_size,
-                    font_family,
-                    text_align,
-                    locked
-                ) VALUES (
-                    $1, $2, $3, $4, $5, $6, $7, $8,
-                    $9, $10, $11, $12, $13, $14
-                )
-                RETURNING *
-            `, [
+            values.push(`($${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++}, $${paramIndex++})`);
+            flatValues.push(
                 templateId,
                 field.role_name || null,
                 field.field_type,
@@ -1268,10 +1256,30 @@ async function replaceTemplateFields(pool, templateId, fields) {
                 field.font_family || null,
                 field.text_align || null,
                 field.locked || false
-            ]);
-            inserted.push(result.rows[0]);
+            );
         }
-        return inserted;
+
+        const result = await client.query(`
+            INSERT INTO signature_template_fields (
+                template_id,
+                role_name,
+                field_type,
+                page_number,
+                x_position,
+                y_position,
+                width,
+                height,
+                label,
+                is_required,
+                font_size,
+                font_family,
+                text_align,
+                locked
+            ) VALUES ${values.join(', ')}
+            RETURNING *
+        `, flatValues);
+
+        return result.rows;
     });
 }
 


### PR DESCRIPTION
💡 **What:** Refactored the `replaceTemplateFields` function in `signature.service.js` to execute a single bulk `INSERT` query instead of multiple single `INSERT` queries within a loop.

🎯 **Why:** The previous implementation executed a separate `INSERT` statement for each field in the `fields` array. This causes an N+1 query issue, leading to N database roundtrips. For templates with many fields, this can cause significant latency and unnecessary load on the PostgreSQL server. By batching all inserts into a single `INSERT ... VALUES ($1, $2, ...), ($15, ...)` statement, we reduce the operation to just 2 queries: one `DELETE` and one `INSERT`.

📊 **Measured Improvement:** A local mock benchmark was written to measure the difference in constructing and executing the queries (without full network latency).
*   **Baseline (N+1 approach for 500 items):** ~23.3ms, 501 total queries (1 DELETE + 500 INSERTs).
*   **Optimized (Bulk insert for 500 items):** ~17.4ms, 2 total queries (1 DELETE + 1 Bulk INSERT).
*   **Change:** A minor CPU reduction in query construction/execution time (~25%), but the primary benefit is the **reduction in network roundtrips from 501 to 2**. In a real-world deployed environment, eliminating 499 network calls to the database will yield a massive latency improvement (likely saving 500ms - 2s depending on network latency to the DB).

---
*PR created automatically by Jules for task [3343008497798427008](https://jules.google.com/task/3343008497798427008) started by @codebymv*