### PR TITLE
🧹 [Code Health] Implement trial ending email notification

### DIFF
--- a/backend/src/__tests__/services/stripeSubscriptionService.test.js
+++ b/backend/src/__tests__/services/stripeSubscriptionService.test.js
@@ -1,0 +1,90 @@
+const StripeSubscriptionService = require('../../services/stripeSubscriptionService');
+const emailService = require('../../services/emailService');
+
+jest.mock('../../services/emailService', () => ({
+    sendTemplateEmail: jest.fn()
+}));
+
+describe('StripeSubscriptionService', () => {
+    let service;
+    let poolMock;
+
+    beforeEach(() => {
+        poolMock = {
+            query: jest.fn()
+        };
+        service = new StripeSubscriptionService(poolMock);
+        // Mock logging to avoid noise
+        service.logInfo = jest.fn();
+        service.logError = jest.fn();
+        service.logWarn = jest.fn();
+        service.logSubscriptionEvent = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('handleTrialEnding', () => {
+        it('should log subscription event and send trial ending email', async () => {
+            const organizationId = 123;
+            const subscriptionId = 'sub_123';
+            const trialEnd = Math.floor(Date.now() / 1000) + 86400 * 3; // 3 days from now
+
+            const subscription = {
+                id: subscriptionId,
+                trial_end: trialEnd,
+                metadata: { organizationId: organizationId.toString() }
+            };
+
+            const mockOrg = { email: 'test@example.com', name: 'Test Org' };
+            poolMock.query.mockResolvedValueOnce({ rows: [mockOrg] });
+
+            await service.handleTrialEnding(subscription);
+
+            expect(service.logSubscriptionEvent).toHaveBeenCalledWith(
+                organizationId,
+                subscriptionId,
+                'trial_ending',
+                { trialEnd }
+            );
+
+            expect(poolMock.query).toHaveBeenCalledWith(
+                'SELECT email, name FROM organizations WHERE id = $1',
+                [organizationId]
+            );
+
+            expect(emailService.sendTemplateEmail).toHaveBeenCalledWith({
+                template: expect.objectContaining({
+                    subject: 'Your trial is ending soon',
+                    body_html: expect.stringContaining(mockOrg.name)
+                }),
+                contact: { email: mockOrg.email, first_name: mockOrg.name }
+            });
+
+            expect(service.logInfo).toHaveBeenCalledWith(
+                'Sent trial ending email notification',
+                { organizationId, email: mockOrg.email }
+            );
+        });
+
+        it('should warn if organization or email is not found', async () => {
+            const organizationId = 123;
+            const subscription = {
+                id: 'sub_123',
+                trial_end: 1234567890,
+                metadata: { organizationId: organizationId.toString() }
+            };
+
+            poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+            await service.handleTrialEnding(subscription);
+
+            expect(emailService.sendTemplateEmail).not.toHaveBeenCalled();
+            expect(service.logWarn).toHaveBeenCalledWith(
+                'Could not send trial ending email - organization or email not found',
+                { organizationId }
+            );
+        });
+    });
+});

--- a/backend/src/services/stripeSubscriptionService.js
+++ b/backend/src/services/stripeSubscriptionService.js
@@ -9,6 +9,7 @@
 const BaseService = require('./BaseService');
 const Stripe = require('stripe');
 const { PLAN_NAMES, PRICING, getTierLevel } = require('../config/plans');
+const emailService = require('./emailService');
 
 class StripeSubscriptionService extends BaseService {
     constructor(pool) {
@@ -649,7 +650,40 @@ class StripeSubscriptionService extends BaseService {
             await this.logSubscriptionEvent(organizationId, subscription.id, 'trial_ending', {
                 trialEnd: subscription.trial_end
             });
-            // TODO: Send email notification
+
+            try {
+                // Get organization email
+                const orgResult = await this.pool.query(
+                    'SELECT email, name FROM organizations WHERE id = $1',
+                    [organizationId]
+                );
+
+                const org = orgResult.rows[0];
+                if (org && org.email) {
+                    const trialEndDate = new Date(subscription.trial_end * 1000).toLocaleDateString();
+                    const template = {
+                        subject: 'Your trial is ending soon',
+                        body_html: `
+                            <h2>Hello ${org.name || 'there'},</h2>
+                            <p>We hope you are enjoying your trial. This is a quick reminder that your trial period will end on <strong>${trialEndDate}</strong>.</p>
+                            <p>To ensure uninterrupted access to all features, please make sure your billing information is up to date.</p>
+                            <br/>
+                            <a href="{{billingUrl}}" class="button-primary">Update Billing Information</a>
+                        `
+                    };
+
+                    await emailService.sendTemplateEmail({
+                        template,
+                        contact: { email: org.email, first_name: org.name }
+                    });
+
+                    this.logInfo('Sent trial ending email notification', { organizationId, email: org.email });
+                } else {
+                    this.logWarn('Could not send trial ending email - organization or email not found', { organizationId });
+                }
+            } catch (error) {
+                this.logError('Failed to send trial ending email notification', error);
+            }
         }
     }
 


### PR DESCRIPTION
🎯 **What:** Implemented the TODO in `stripeSubscriptionService.js` to send an email notification when an organization's trial is ending.
💡 **Why:** Automating the trial-ending communication improves customer conversion to paid plans by reminding them to update their billing information.
✅ **Verification:** Added comprehensive unit tests in `src/__tests__/services/stripeSubscriptionService.test.js` covering both the successful email dispatch path and the case where organization data cannot be found. Ran `npm test -t stripeSubscriptionService` locally to confirm all tests pass.
✨ **Result:** Organizations will now receive a friendly, automated email reminder when their trial is approaching its end date, encouraging them to update their billing info.

---
*PR created automatically by Jules for task [18048485633115806870](https://jules.google.com/task/18048485633115806870) started by @codebymv*