### PR TITLE
⚡ Optimize signature fields bulk insert

### DIFF
--- a/backend/patch_final.js
+++ b/backend/patch_final.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+let content = fs.readFileSync('src/services/signature.service.js', 'utf8');
+
+const regex = /if \(fields && fields\.length > 0\) \{[\s\S]*?inserted = result\.rows;\n        \}/;
+const replace = `if (fields && fields.length > 0) {
+            const documentIds = [];
+            const recipientIds = [];
+            const roleNames = [];
+            const fieldTypes = [];
+            const pageNumbers = [];
+            const xPositions = [];
+            const yPositions = [];
+            const widths = [];
+            const heights = [];
+            const labels = [];
+            const isRequireds = [];
+            const fieldValues = [];
+            const fontSizes = [];
+            const fontFamilies = [];
+            const textAligns = [];
+            const lockeds = [];
+
+            for (const field of fields) {
+                documentIds.push(documentId);
+                recipientIds.push(field.recipient_id || null);
+                roleNames.push(field.role_name || null);
+                fieldTypes.push(field.field_type);
+                pageNumbers.push(field.page_number || 1);
+                xPositions.push(field.x_position);
+                yPositions.push(field.y_position);
+                widths.push(field.width);
+                heights.push(field.height);
+                labels.push(field.label || null);
+                isRequireds.push(field.is_required !== undefined ? field.is_required : true);
+                fieldValues.push(field.value || null);
+                fontSizes.push(field.font_size || null);
+                fontFamilies.push(field.font_family || null);
+                textAligns.push(field.text_align || null);
+                lockeds.push(field.locked || false);
+            }
+
+            const result = await client.query(\`
+                INSERT INTO signature_fields (
+                    document_id, recipient_id, role_name, field_type, page_number,
+                    x_position, y_position, width, height, label,
+                    is_required, value, font_size, font_family, text_align, locked
+                )
+                SELECT * FROM UNNEST (
+                    $1::uuid[], $2::uuid[], $3::text[], $4::text[], $5::int[],
+                    $6::numeric[], $7::numeric[], $8::numeric[], $9::numeric[], $10::text[],
+                    $11::boolean[], $12::text[], $13::int[], $14::text[], $15::text[], $16::boolean[]
+                )
+                RETURNING *
+            \`, [
+                documentIds, recipientIds, roleNames, fieldTypes, pageNumbers,
+                xPositions, yPositions, widths, heights, labels,
+                isRequireds, fieldValues, fontSizes, fontFamilies, textAligns, lockeds
+            ]);
+            inserted = result.rows;
+        }`;
+
+content = content.replace(regex, replace);
+fs.writeFileSync('src/services/signature.service.js', content);
+console.log('Done');

--- a/backend/src/services/signature.service.js
+++ b/backend/src/services/signature.service.js
@@ -428,54 +428,59 @@ async function replaceFields(pool, documentId, fields) {
 
         let inserted = [];
         if (fields && fields.length > 0) {
-            const values = [];
-            const flatParams = [];
-            let paramIndex = 1;
+            const documentIds = [];
+            const recipientIds = [];
+            const roleNames = [];
+            const fieldTypes = [];
+            const pageNumbers = [];
+            const xPositions = [];
+            const yPositions = [];
+            const widths = [];
+            const heights = [];
+            const labels = [];
+            const isRequireds = [];
+            const fieldValues = [];
+            const fontSizes = [];
+            const fontFamilies = [];
+            const textAligns = [];
+            const lockeds = [];
 
             for (const field of fields) {
-                values.push(`($${paramIndex}, $${paramIndex + 1}, $${paramIndex + 2}, $${paramIndex + 3}, $${paramIndex + 4}, $${paramIndex + 5}, $${paramIndex + 6}, $${paramIndex + 7}, $${paramIndex + 8}, $${paramIndex + 9}, $${paramIndex + 10}, $${paramIndex + 11}, $${paramIndex + 12}, $${paramIndex + 13}, $${paramIndex + 14}, $${paramIndex + 15})`);
-                flatParams.push(
-                    documentId,
-                    field.recipient_id || null,
-                    field.role_name || null,
-                    field.field_type,
-                    field.page_number || 1,
-                    field.x_position,
-                    field.y_position,
-                    field.width,
-                    field.height,
-                    field.label || null,
-                    field.is_required !== undefined ? field.is_required : true,
-                    field.value || null,
-                    field.font_size || null,
-                    field.font_family || null,
-                    field.text_align || null,
-                    field.locked || false
-                );
-                paramIndex += 16;
+                documentIds.push(documentId);
+                recipientIds.push(field.recipient_id || null);
+                roleNames.push(field.role_name || null);
+                fieldTypes.push(field.field_type);
+                pageNumbers.push(field.page_number || 1);
+                xPositions.push(field.x_position);
+                yPositions.push(field.y_position);
+                widths.push(field.width);
+                heights.push(field.height);
+                labels.push(field.label || null);
+                isRequireds.push(field.is_required !== undefined ? field.is_required : true);
+                fieldValues.push(field.value || null);
+                fontSizes.push(field.font_size || null);
+                fontFamilies.push(field.font_family || null);
+                textAligns.push(field.text_align || null);
+                lockeds.push(field.locked || false);
             }
 
             const result = await client.query(`
                 INSERT INTO signature_fields (
-                    document_id,
-                    recipient_id,
-                    role_name,
-                    field_type,
-                    page_number,
-                    x_position,
-                    y_position,
-                    width,
-                    height,
-                    label,
-                    is_required,
-                    value,
-                    font_size,
-                    font_family,
-                    text_align,
-                    locked
-                ) VALUES ${values.join(', ')}
+                    document_id, recipient_id, role_name, field_type, page_number,
+                    x_position, y_position, width, height, label,
+                    is_required, value, font_size, font_family, text_align, locked
+                )
+                SELECT * FROM UNNEST (
+                    $1::uuid[], $2::uuid[], $3::text[], $4::text[], $5::int[],
+                    $6::numeric[], $7::numeric[], $8::numeric[], $9::numeric[], $10::text[],
+                    $11::boolean[], $12::text[], $13::int[], $14::text[], $15::text[], $16::boolean[]
+                )
                 RETURNING *
-            `, flatParams);
+            `, [
+                documentIds, recipientIds, roleNames, fieldTypes, pageNumbers,
+                xPositions, yPositions, widths, heights, labels,
+                isRequireds, fieldValues, fontSizes, fontFamilies, textAligns, lockeds
+            ]);
             inserted = result.rows;
         }
 

--- a/patch_replaceFields.diff
+++ b/patch_replaceFields.diff
@@ -1,0 +1,90 @@
+--- backend/src/services/signature.service.js
++++ backend/src/services/signature.service.js
+@@ -432,56 +432,44 @@
+
+         let inserted = [];
+         if (fields && fields.length > 0) {
+-            const values = [];
+-            const flatParams = [];
+-            let paramIndex = 1;
++            const documentIds = [];
++            const recipientIds = [];
++            const roleNames = [];
++            const fieldTypes = [];
++            const pageNumbers = [];
++            const xPositions = [];
++            const yPositions = [];
++            const widths = [];
++            const heights = [];
++            const labels = [];
++            const isRequireds = [];
++            const fieldValues = [];
++            const fontSizes = [];
++            const fontFamilies = [];
++            const textAligns = [];
++            const lockeds = [];
+
+             for (const field of fields) {
+-                values.push(`($${paramIndex}, $${paramIndex + 1}, $${paramIndex + 2}, $${paramIndex + 3}, $${paramIndex + 4}, $${paramIndex + 5}, $${paramIndex + 6}, $${paramIndex + 7}, $${paramIndex + 8}, $${paramIndex + 9}, $${paramIndex + 10}, $${paramIndex + 11}, $${paramIndex + 12}, $${paramIndex + 13}, $${paramIndex + 14}, $${paramIndex + 15})`);
+-                flatParams.push(
+-                    documentId,
+-                    field.recipient_id || null,
+-                    field.role_name || null,
+-                    field.field_type,
+-                    field.page_number || 1,
+-                    field.x_position,
+-                    field.y_position,
+-                    field.width,
+-                    field.height,
+-                    field.label || null,
+-                    field.is_required !== undefined ? field.is_required : true,
+-                    field.value || null,
+-                    field.font_size || null,
+-                    field.font_family || null,
+-                    field.text_align || null,
+-                    field.locked || false
+-                );
+-                paramIndex += 16;
++                documentIds.push(documentId);
++                recipientIds.push(field.recipient_id || null);
++                roleNames.push(field.role_name || null);
++                fieldTypes.push(field.field_type);
++                pageNumbers.push(field.page_number || 1);
++                xPositions.push(field.x_position);
++                yPositions.push(field.y_position);
++                widths.push(field.width);
++                heights.push(field.height);
++                labels.push(field.label || null);
++                isRequireds.push(field.is_required !== undefined ? field.is_required : true);
++                fieldValues.push(field.value || null);
++                fontSizes.push(field.font_size || null);
++                fontFamilies.push(field.font_family || null);
++                textAligns.push(field.text_align || null);
++                lockeds.push(field.locked || false);
+             }
+
+             const result = await client.query(`
+-                INSERT INTO signature_fields (
+-                    document_id,
+-                    recipient_id,
+-                    role_name,
+-                    field_type,
+-                    page_number,
+-                    x_position,
+-                    y_position,
+-                    width,
+-                    height,
+-                    label,
+-                    is_required,
+-                    value,
+-                    font_size,
+-                    font_family,
+-                    text_align,
+-                    locked
+-                ) VALUES ${values.join(', ')}
++                INSERT INTO signature_fields (document_id, recipient_id, role_name, field_type, page_number, x_position, y_position, width, height, label, is_required, value, font_size, font_family, text_align, locked) SELECT * FROM UNNEST ($1::uuid[], $2::uuid[], $3::text[], $4::text[], $5::int[], $6::numeric[], $7::numeric[], $8::numeric[], $9::numeric[], $10::text[], $11::boolean[], $12::text[], $13::int[], $14::text[], $15::text[], $16::boolean[])
+                 RETURNING *
+-            `, flatParams);
++            `, [documentIds, recipientIds, roleNames, fieldTypes, pageNumbers, xPositions, yPositions, widths, heights, labels, isRequireds, fieldValues, fontSizes, fontFamilies, textAligns, lockeds]);
+             inserted = result.rows;
+         }

--- a/patch_replaceFields.js
+++ b/patch_replaceFields.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+let code = fs.readFileSync('backend/src/services/signature.service.js', 'utf8');
+
+const regex = /let inserted = \[\];\s+if \(fields && fields\.length > 0\) \{[\s\S]*?inserted = result\.rows;\s+\}/;
+
+const replace = `let inserted = [];
+        if (fields && fields.length > 0) {
+            const documentIds = [];
+            const recipientIds = [];
+            const roleNames = [];
+            const fieldTypes = [];
+            const pageNumbers = [];
+            const xPositions = [];
+            const yPositions = [];
+            const widths = [];
+            const heights = [];
+            const labels = [];
+            const isRequireds = [];
+            const fieldValues = [];
+            const fontSizes = [];
+            const fontFamilies = [];
+            const textAligns = [];
+            const lockeds = [];
+
+            for (const field of fields) {
+                documentIds.push(documentId);
+                recipientIds.push(field.recipient_id || null);
+                roleNames.push(field.role_name || null);
+                fieldTypes.push(field.field_type);
+                pageNumbers.push(field.page_number || 1);
+                xPositions.push(field.x_position);
+                yPositions.push(field.y_position);
+                widths.push(field.width);
+                heights.push(field.height);
+                labels.push(field.label || null);
+                isRequireds.push(field.is_required !== undefined ? field.is_required : true);
+                fieldValues.push(field.value || null);
+                fontSizes.push(field.font_size || null);
+                fontFamilies.push(field.font_family || null);
+                textAligns.push(field.text_align || null);
+                lockeds.push(field.locked || false);
+            }
+
+            const result = await client.query(\`
+                INSERT INTO signature_fields (
+                    document_id, recipient_id, role_name, field_type, page_number,
+                    x_position, y_position, width, height, label,
+                    is_required, value, font_size, font_family, text_align, locked
+                )
+                SELECT * FROM UNNEST (
+                    $1::uuid[], $2::uuid[], $3::text[], $4::text[], $5::int[],
+                    $6::numeric[], $7::numeric[], $8::numeric[], $9::numeric[], $10::text[],
+                    $11::boolean[], $12::text[], $13::int[], $14::text[], $15::text[], $16::boolean[]
+                )
+                RETURNING *
+            \`, [
+                documentIds, recipientIds, roleNames, fieldTypes, pageNumbers,
+                xPositions, yPositions, widths, heights, labels,
+                isRequireds, fieldValues, fontSizes, fontFamilies, textAligns, lockeds
+            ]);
+            inserted = result.rows;
+        }`;
+
+if (regex.test(code)) {
+    fs.writeFileSync('backend/src/services/signature.service.js', code.replace(regex, replace));
+    console.log('SUCCESS');
+} else {
+    console.log('FAIL TO MATCH');
+}


### PR DESCRIPTION
💡 What: The optimization replaces the string concatenated `VALUES` multi-insert syntax in `replaceFields` with a `SELECT * FROM UNNEST` bulk insert approach.
🎯 Why: It solves potential scaling bottlenecks when replacing hundreds of fields at a time, eliminating the overhead of parsing large parameterized query strings and avoiding the 65,535 bind parameter limit in Postgres.
📊 Measured Improvement: Due to environment limitations, direct profiling wasn't feasible, but replacing multi-insert VALUES blocks with `UNNEST` arrays is a standard optimization strategy to speed up query execution plans and lower connection pool contention.

---
*PR created automatically by Jules for task [17219477335446545974](https://jules.google.com/task/17219477335446545974) started by @codebymv*