### PR TITLE
Fix wireframe sharing on canvas

### DIFF
--- a/frontend/src/pages/canvas.tsx
+++ b/frontend/src/pages/canvas.tsx
@@ -628,7 +628,21 @@ const { currentUser } = useAuthState();
                 onWhiteboardShare={handleShareWhiteboard}
                 onWireframeUpdate={handleUpdateWireframe}
                 onWireframeDelete={handleDeleteWireframe}
-                onWireframeShare={handleShareWireframe}
+                onWireframeShare={(wireframeId) => {
+                  const wireframe = wireframes.find(w => w.id === wireframeId);
+                  if (wireframe) {
+                    setCurrentShareItem({
+                      id: wireframeId,
+                      title: wireframe.title || 'Untitled Wireframe',
+                      itemType: 'wireframe',
+                      shareData: wireframe.share_token && wireframe.is_public ? {
+                        shareToken: wireframe.share_token,
+                        shareUrl: `${window.location.origin}/shared/wireframe/${wireframe.share_token}`
+                      } : undefined
+                    });
+                    setShowShareModal(true);
+                  }
+                }}
                 onWireframePositionUpdate={handleWireframePositionChange}
                 onVaultUpdate={handleUpdateVault}
                 onVaultDelete={handleDeleteVault}


### PR DESCRIPTION
Implemented logic to share a wireframe item on the canvas directly through `onWireframeShare`. The item sets current share item data appropriately and opens the share modal.

---
*PR created automatically by Jules for task [10378767799540871172](https://jules.google.com/task/10378767799540871172) started by @codebymv*