### PR TITLE
feat: Implement resend functionality for review requests

### DIFF
--- a/backend/src/routes/reputation.routes.js
+++ b/backend/src/routes/reputation.routes.js
@@ -8,6 +8,8 @@ const router = express.Router();
 const crypto = require('crypto');
 const { withDbClient } = require('../utils/db');
 const { sendError } = require('../utils/response');
+const emailService = require('../services/emailService');
+const smsService = require('../services/smsService');
 
 module.exports = (pool, authenticateJWT, publicRateLimit) => {
     const { requireOrganization } = require('../middleware/organization')(pool);
@@ -506,6 +508,87 @@ module.exports = (pool, authenticateJWT, publicRateLimit) => {
         } catch (error) {
             console.error('Error creating review request:', error);
             return sendError(res, 'Failed to create review request');
+        }
+    });
+
+    /**
+     * POST /api/reputation/requests/:id/resend - Resend review request
+     */
+    router.post('/requests/:id/resend', authenticateJWT, requireOrganization, async (req, res) => {
+        try {
+            const { id } = req.params;
+
+            const request = await withDbClient(pool, async (client) => {
+                // Get existing request
+                const result = await client.query(
+                    'SELECT * FROM review_requests WHERE id = $1 AND organization_id = $2',
+                    [id, req.organizationId]
+                );
+
+                if (result.rows.length === 0) {
+                    return null;
+                }
+
+                const existingRequest = result.rows[0];
+
+                // Update request
+                const updatedResult = await client.query(`
+                    UPDATE review_requests SET
+                        status = 'sent',
+                        email_sent = CASE WHEN channel IN ('email', 'both') THEN true ELSE email_sent END,
+                        email_sent_at = CASE WHEN channel IN ('email', 'both') THEN CURRENT_TIMESTAMP ELSE email_sent_at END,
+                        sms_sent = CASE WHEN channel IN ('sms', 'both') THEN true ELSE sms_sent END,
+                        sms_sent_at = CASE WHEN channel IN ('sms', 'both') THEN CURRENT_TIMESTAMP ELSE sms_sent_at END,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = $1
+                    RETURNING *
+                `, [id]);
+
+                const requestData = updatedResult.rows[0];
+
+                // Get organization details for email/sms
+                const orgResult = await client.query('SELECT name FROM organizations WHERE id = $1', [req.organizationId]);
+                const orgName = orgResult.rows[0]?.name || 'us';
+
+                const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
+                const reviewLink = `${frontendUrl}/r/${requestData.unique_token}`;
+
+                // Get custom message or use default
+                const messageBody = requestData.custom_message || `Hi ${requestData.contact_name || 'there'}, we'd love to hear about your experience with ${orgName}. Please leave us a review: ${reviewLink}`;
+
+                // Send email if requested
+                if (requestData.channel === 'email' || requestData.channel === 'both') {
+                    if (requestData.contact_email && emailService.isEnabled()) {
+                        await emailService.sendEmail({
+                            to: requestData.contact_email,
+                            subject: `How did we do? Leave a review for ${orgName}`,
+                            text: messageBody,
+                            html: `<p>${messageBody.replace(/\n/g, '<br>')}</p>`,
+                        });
+                    }
+                }
+
+                // Send SMS if requested
+                if (requestData.channel === 'sms' || requestData.channel === 'both') {
+                    if (requestData.contact_phone && smsService.isEnabled()) {
+                        await smsService.sendSms({
+                            to: requestData.contact_phone,
+                            message: messageBody,
+                        });
+                    }
+                }
+
+                return requestData;
+            });
+
+            if (!request) {
+                return res.status(404).json({ error: 'Review request not found' });
+            }
+
+            res.json(request);
+        } catch (error) {
+            console.error('Error resending review request:', error);
+            return sendError(res, 'Failed to resend review request');
         }
     });
 

--- a/frontend/src/pages/reputation/ReputationRequestsPage.tsx
+++ b/frontend/src/pages/reputation/ReputationRequestsPage.tsx
@@ -24,7 +24,7 @@ import { ListRowSkeleton } from '@/components/ui/loading-skeletons';
 import { useToast } from '@/hooks/use-toast';
 import { useHeader } from '@/contexts/HeaderContext';
 import { useOrganization } from '@/hooks/useOrganization';
-import { getReviewRequests, deleteReviewRequest, sendReviewRequest } from '@/services/reputationApi';
+import { getReviewRequests, deleteReviewRequest, sendReviewRequest, resendReviewRequest } from '@/services/reputationApi';
 import { SendReviewRequestModal } from './SendReviewRequestModal';
 import { MobileControlsBar } from '@/components/MobileControlsBar';
 import { PageContainer, PageSurface } from '@/components/layout/PageContainer';
@@ -142,8 +142,14 @@ export function ReputationRequestsPage() {
     }, [fetchRequests]);
 
     const handleResend = async (id: number) => {
-        // TODO: Implement resend functionality when backend endpoint is available
-        toast({ title: 'Coming soon', description: 'Resend functionality will be available soon' });
+        if (!organizationId) return;
+        try {
+            await resendReviewRequest(id, organizationId);
+            toast({ title: 'Success', description: 'Review request resent successfully' });
+            fetchRequests(); // Refresh the list to update statuses/timestamps
+        } catch (error) {
+            toast({ title: 'Error', description: 'Failed to resend request', variant: 'destructive' });
+        }
     };
 
     const handleDelete = async (id: number) => {

--- a/frontend/src/services/reputationApi.ts
+++ b/frontend/src/services/reputationApi.ts
@@ -185,6 +185,16 @@ export const getPlatforms = async (organizationId?: number): Promise<ReviewPlatf
     return response.data;
 };
 
+export const resendReviewRequest = async (
+    requestId: number,
+    organizationId?: number
+): Promise<ReviewRequest> => {
+    const response = await api.post(`/api/reputation/requests/${requestId}/resend`, {}, {
+        headers: organizationId ? { 'x-organization-id': organizationId.toString() } : {}
+    });
+    return response.data;
+};
+
 export const addPlatform = async (
     platform: Partial<ReviewPlatform>,
     organizationId?: number
@@ -439,6 +449,7 @@ export default {
     sendReviewRequest,
     sendBulkReviewRequests,
     deleteReviewRequest,
+    resendReviewRequest,
     // Widgets
     getWidgets,
     createWidget,


### PR DESCRIPTION
This Pull Request adds the ability to resend review requests from the Reputation Requests Page.

### What
- Added a new backend endpoint `POST /api/reputation/requests/:id/resend`.
- The endpoint retrieves the existing request and updates its status (`email_sent`, `sms_sent`, etc.).
- Integrated `emailService` and `smsService` in the route to actively send out the message upon a resend.
- Updated `frontend/src/services/reputationApi.ts` with `resendReviewRequest`.
- Linked the `handleResend` function in `frontend/src/pages/reputation/ReputationRequestsPage.tsx` to call the new endpoint, display a success toast, and refresh the UI.

### Verification
- Tested the endpoint locally and confirmed it parses the request correctly and utilizes the `sendEmail`/`sendSms` service functions appropriately based on the selected channel.
- Built and linted the frontend to ensure no regressions.

---
*PR created automatically by Jules for task [8231117144354456892](https://jules.google.com/task/8231117144354456892) started by @codebymv*