### PR TITLE
fix: update workspaces text gradient on homepage

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -411,7 +411,7 @@ const Home: React.FC = () => {
                   </div>
                   <h2 className={`landing-heading text-3xl md:text-4xl lg:text-5xl font-extrabold ${textColor} mb-6 leading-tight`}>
                     The only CRM with built-in{' '}
-                    <span className="landing-gradient-text">Workspaces</span>
+                    <span className={`bg-clip-text text-transparent ${accentGradient}`}>Workspaces</span>
                   </h2>
                   <p className={`text-lg leading-relaxed ${secondaryTextColor} mb-8`}>
                     Other CRMs force you to keep notes in separate apps. Itemize includes 


### PR DESCRIPTION
### 🎯 What
Updated the text gradient on the word "Workspaces" in the CRM section of the landing page.

### 💡 Why
The user requested that the "Workspaces" gradient be changed to match the other blue-600 gradients found on the homepage. It was using a custom `landing-gradient-text` that did not align with the standard `accentGradient` style used for other headings.

### ✅ Verification
- Ran the frontend dev server and captured a screenshot of the modified section.
- Visually verified that the gradient accurately matches the `accentGradient` variable (`from-blue-600 to-indigo-600`).
- Ran frontend code linting to ensure no regressions in styling application.

---
*PR created automatically by Jules for task [9893468270244319789](https://jules.google.com/task/9893468270244319789) started by @codebymv*