### PR TITLE
Fix hero section image cropping on landing page

### DIFF
--- a/frontend/src/pages/home/components/AppScreenshot.tsx
+++ b/frontend/src/pages/home/components/AppScreenshot.tsx
@@ -76,7 +76,7 @@ const AppScreenshot = memo(function AppScreenshot({
         <img 
           src={src} 
           alt={alt || label}
-          className={`w-full ${aspectRatio} object-cover object-top`}
+          className={`w-full h-auto object-contain object-top`}
           loading="lazy"
         />
       ) : (


### PR DESCRIPTION
Fixes an issue on the landing page where the dashboard screenshot in the hero section was being cropped. The image styling has been updated to use `object-contain` instead of `object-cover` and a fixed aspect ratio to ensure the full image is visible.

Verification:
- The frontend build succeeds.
- Generated visual verification via Playwright to ensure the image is no longer cropped and renders appropriately on the landing page.

---
*PR created automatically by Jules for task [1157605492380330282](https://jules.google.com/task/1157605492380330282) started by @codebymv*