### PR TITLE
⚡ Batch Canvas Positions Update using PostgreSQL UNNEST

### DIFF
--- a/backend/benchmark_canvas_notes.js
+++ b/backend/benchmark_canvas_notes.js
@@ -1,0 +1,79 @@
+async function benchmark() {
+  const userId = 1;
+  const numNotes = 500;
+
+  // Create update objects
+  const updates = Array.from({length: numNotes}).map((_, i) => ({
+    type: 'note',
+    id: i,
+    position_x: i * 2,
+    position_y: i * 2,
+    width: 200,
+    height: 200
+  }));
+
+  // Benchmark Original (Sequential updates preparation)
+  const startSequential = Date.now();
+  let queryCalls = 0;
+  for (const update of updates) {
+    // Simulating the work of building and executing individual queries
+    const query = 'UPDATE notes SET position_x = $1, position_y = $2, width = COALESCE($3, width), height = COALESCE($4, height) WHERE id = $5 AND user_id = $6 RETURNING *';
+    const params = [update.position_x, update.position_y, update.width ?? null, update.height ?? null, update.id, userId];
+    queryCalls++;
+  }
+  const endSequential = Date.now();
+  const timeSequential = endSequential - startSequential;
+  console.log(`Original Pattern: Makes ${queryCalls} individual queries (1 per note)`);
+  console.log(`Original Time (Query preparation loop for ${numNotes} notes): ${timeSequential}ms`);
+
+  // Benchmark Optimized (UNNEST batch update preparation)
+  const startUnnest = Date.now();
+
+  const u_ids = [];
+  const u_pos_xs = [];
+  const u_pos_ys = [];
+  const u_widths = [];
+  const u_heights = [];
+
+  for (const update of updates) {
+    u_ids.push(update.id);
+    u_pos_xs.push(update.position_x);
+    u_pos_ys.push(update.position_y);
+    u_widths.push(update.width ?? null);
+    u_heights.push(update.height ?? null);
+  }
+
+  const query = `
+    UPDATE notes AS n
+    SET
+        position_x = u.position_x,
+        position_y = u.position_y,
+        width = COALESCE(u.width, n.width),
+        height = COALESCE(u.height, n.height)
+    FROM (
+        SELECT * FROM UNNEST (
+            $1::int[], $2::numeric[], $3::numeric[], $4::numeric[], $5::numeric[]
+        ) AS t(id, position_x, position_y, width, height)
+    ) AS u
+    WHERE n.id = u.id AND n.user_id = $6
+    RETURNING n.*
+  `;
+  const params = [u_ids, u_pos_xs, u_pos_ys, u_widths, u_heights, userId];
+
+  const endUnnest = Date.now();
+  const timeUnnest = endUnnest - startUnnest;
+
+  console.log(`Optimized Pattern: Makes 1 single query for all ${numNotes} notes`);
+  console.log(`Optimized Time (Array preparation for ${numNotes} notes): ${timeUnnest}ms`);
+
+  // Rationale output
+  console.log(`\nRationale:`);
+  console.log(`While preparation time is negligible for both methods (${timeSequential}ms vs ${timeUnnest}ms),`);
+  console.log(`the N+1 query issue causes severe overhead in production due to:`);
+  console.log(`1. Database round-trip latency (${queryCalls} network requests vs 1)`);
+  console.log(`2. PostgreSQL connection pool exhaustion`);
+  console.log(`3. Query parsing overhead (PostgreSQL must parse/plan ${queryCalls} queries instead of 1)`);
+  console.log(`Using UNNEST reduces the complexity from O(n) database queries to O(1) query.`);
+}
+
+benchmark();

--- a/backend/src/routes/canvas.routes.js
+++ b/backend/src/routes/canvas.routes.js
@@ -19,26 +19,66 @@ module.exports = (pool, authenticateJWT, broadcast) => {
       const failed = [];
 
       await withDbClient(pool, async (client) => {
+        const updatesByType = {
+          list: [],
+          note: [],
+          whiteboard: [],
+          wireframe: [],
+          vault: []
+        };
+
         for (const update of updates) {
-          const { type, id, position_x, position_y, width, height } = update || {};
+          const { type, id, position_x, position_y } = update || {};
 
           if (!type || id === undefined || id === null || typeof position_x !== 'number' || typeof position_y !== 'number') {
             failed.push({ type, id, error: 'Invalid update payload' });
             continue;
           }
 
-          if (type === 'list') {
-            const result = await client.query(
-              'UPDATE lists SET position_x = $1, position_y = $2, width = COALESCE($3, width) WHERE id = $4 AND user_id = $5 RETURNING *',
-              [position_x, position_y, width ?? null, id, req.user.id]
-            );
+          if (updatesByType[type]) {
+            updatesByType[type].push(update);
+          } else {
+            failed.push({ type, id, error: 'Unknown update type' });
+          }
+        }
 
-            if (result.rows.length === 0) {
-              failed.push({ type, id, error: 'List not found' });
-              continue;
+        if (updatesByType.list.length > 0) {
+          const u_ids = [];
+          const u_pos_xs = [];
+          const u_pos_ys = [];
+          const u_widths = [];
+
+          for (const update of updatesByType.list) {
+            u_ids.push(update.id);
+            u_pos_xs.push(update.position_x);
+            u_pos_ys.push(update.position_y);
+            u_widths.push(update.width ?? null);
+          }
+
+          const result = await client.query(`
+            UPDATE lists AS l
+            SET
+              position_x = u.position_x,
+              position_y = u.position_y,
+              width = COALESCE(u.width, l.width)
+            FROM (
+              SELECT * FROM UNNEST(
+                $1::int[], $2::numeric[], $3::numeric[], $4::numeric[]
+              ) AS t(id, position_x, position_y, width)
+            ) AS u
+            WHERE l.id = u.id AND l.user_id = $5
+            RETURNING l.*
+          `, [u_ids, u_pos_xs, u_pos_ys, u_widths, req.user.id]);
+
+          const foundIds = new Set(result.rows.map(r => r.id));
+
+          for (const update of updatesByType.list) {
+            if (!foundIds.has(update.id)) {
+              failed.push({ type: 'list', id: update.id, error: 'List not found' });
             }
+          }
 
-            const row = result.rows[0];
+          for (const row of result.rows) {
             if (row.is_public && row.share_token && broadcast?.listUpdate) {
               broadcast.listUpdate(row.share_token, 'POSITION_UPDATE', {
                 id: row.id,
@@ -46,39 +86,88 @@ module.exports = (pool, authenticateJWT, broadcast) => {
                 position_y: row.position_y
               });
             }
+            updated.push({ type: 'list', id: row.id, position_x: row.position_x, position_y: row.position_y, width: row.width });
+          }
+        }
 
-            updated.push({ type, id: row.id, position_x: row.position_x, position_y: row.position_y, width: row.width });
-            continue;
+        if (updatesByType.note.length > 0) {
+          const u_ids = [];
+          const u_pos_xs = [];
+          const u_pos_ys = [];
+          const u_widths = [];
+          const u_heights = [];
+
+          for (const update of updatesByType.note) {
+            u_ids.push(update.id);
+            u_pos_xs.push(update.position_x);
+            u_pos_ys.push(update.position_y);
+            u_widths.push(update.width ?? null);
+            u_heights.push(update.height ?? null);
           }
 
-          if (type === 'note') {
-            const result = await client.query(
-              'UPDATE notes SET position_x = $1, position_y = $2, width = COALESCE($3, width), height = COALESCE($4, height) WHERE id = $5 AND user_id = $6 RETURNING *',
-              [position_x, position_y, width ?? null, height ?? null, id, req.user.id]
-            );
+          const result = await client.query(`
+            UPDATE notes AS n
+            SET
+              position_x = u.position_x,
+              position_y = u.position_y,
+              width = COALESCE(u.width, n.width),
+              height = COALESCE(u.height, n.height)
+            FROM (
+              SELECT * FROM UNNEST(
+                $1::int[], $2::numeric[], $3::numeric[], $4::numeric[], $5::numeric[]
+              ) AS t(id, position_x, position_y, width, height)
+            ) AS u
+            WHERE n.id = u.id AND n.user_id = $6
+            RETURNING n.*
+          `, [u_ids, u_pos_xs, u_pos_ys, u_widths, u_heights, req.user.id]);
 
-            if (result.rows.length === 0) {
-              failed.push({ type, id, error: 'Note not found' });
-              continue;
+          const foundIds = new Set(result.rows.map(r => r.id));
+
+          for (const update of updatesByType.note) {
+            if (!foundIds.has(update.id)) {
+              failed.push({ type: 'note', id: update.id, error: 'Note not found' });
             }
-
-            const row = result.rows[0];
-            updated.push({ type, id: row.id, position_x: row.position_x, position_y: row.position_y, width: row.width, height: row.height });
-            continue;
           }
 
-          if (type === 'whiteboard') {
-            const result = await client.query(
-              'UPDATE whiteboards SET position_x = $1, position_y = $2 WHERE id = $3 AND user_id = $4 RETURNING *',
-              [position_x, position_y, id, req.user.id]
-            );
+          for (const row of result.rows) {
+            updated.push({ type: 'note', id: row.id, position_x: row.position_x, position_y: row.position_y, width: row.width, height: row.height });
+          }
+        }
 
-            if (result.rows.length === 0) {
-              failed.push({ type, id, error: 'Whiteboard not found' });
-              continue;
+        if (updatesByType.whiteboard.length > 0) {
+          const u_ids = [];
+          const u_pos_xs = [];
+          const u_pos_ys = [];
+
+          for (const update of updatesByType.whiteboard) {
+            u_ids.push(update.id);
+            u_pos_xs.push(update.position_x);
+            u_pos_ys.push(update.position_y);
+          }
+
+          const result = await client.query(`
+            UPDATE whiteboards AS w
+            SET
+              position_x = u.position_x,
+              position_y = u.position_y
+            FROM (
+              SELECT * FROM UNNEST(
+                $1::int[], $2::numeric[], $3::numeric[]
+              ) AS t(id, position_x, position_y)
+            ) AS u
+            WHERE w.id = u.id AND w.user_id = $4
+            RETURNING w.*
+          `, [u_ids, u_pos_xs, u_pos_ys, req.user.id]);
+
+          const foundIds = new Set(result.rows.map(r => r.id));
+
+          for (const update of updatesByType.whiteboard) {
+            if (!foundIds.has(update.id)) {
+              failed.push({ type: 'whiteboard', id: update.id, error: 'Whiteboard not found' });
             }
+          }
 
-            const row = result.rows[0];
+          for (const row of result.rows) {
             if (row.is_public && row.share_token && broadcast?.whiteboardUpdate) {
               broadcast.whiteboardUpdate(row.share_token, 'POSITION_UPDATE', {
                 id: row.id,
@@ -86,23 +175,45 @@ module.exports = (pool, authenticateJWT, broadcast) => {
                 position_y: row.position_y
               });
             }
+            updated.push({ type: 'whiteboard', id: row.id, position_x: row.position_x, position_y: row.position_y });
+          }
+        }
 
-            updated.push({ type, id: row.id, position_x: row.position_x, position_y: row.position_y });
-            continue;
+        if (updatesByType.wireframe.length > 0) {
+          const u_ids = [];
+          const u_pos_xs = [];
+          const u_pos_ys = [];
+
+          for (const update of updatesByType.wireframe) {
+            u_ids.push(update.id);
+            u_pos_xs.push(Math.round(update.position_x));
+            u_pos_ys.push(Math.round(update.position_y));
           }
 
-          if (type === 'wireframe') {
-            const result = await client.query(
-              'UPDATE wireframes SET position_x = $1, position_y = $2, updated_at = NOW() WHERE id = $3 AND user_id = $4 RETURNING *',
-              [Math.round(position_x), Math.round(position_y), id, req.user.id]
-            );
+          const result = await client.query(`
+            UPDATE wireframes AS w
+            SET
+              position_x = u.position_x,
+              position_y = u.position_y,
+              updated_at = NOW()
+            FROM (
+              SELECT * FROM UNNEST(
+                $1::int[], $2::numeric[], $3::numeric[]
+              ) AS t(id, position_x, position_y)
+            ) AS u
+            WHERE w.id = u.id AND w.user_id = $4
+            RETURNING w.*
+          `, [u_ids, u_pos_xs, u_pos_ys, req.user.id]);
 
-            if (result.rows.length === 0) {
-              failed.push({ type, id, error: 'Wireframe not found' });
-              continue;
+          const foundIds = new Set(result.rows.map(r => r.id));
+
+          for (const update of updatesByType.wireframe) {
+            if (!foundIds.has(update.id)) {
+              failed.push({ type: 'wireframe', id: update.id, error: 'Wireframe not found' });
             }
+          }
 
-            const row = result.rows[0];
+          for (const row of result.rows) {
             if (row.is_public && row.share_token && broadcast?.wireframeUpdate) {
               broadcast.wireframeUpdate(row.share_token, 'POSITION_UPDATE', {
                 id: row.id,
@@ -117,28 +228,53 @@ module.exports = (pool, authenticateJWT, broadcast) => {
                 position_y: row.position_y
               });
             }
+            updated.push({ type: 'wireframe', id: row.id, position_x: row.position_x, position_y: row.position_y });
+          }
+        }
 
-            updated.push({ type, id: row.id, position_x: row.position_x, position_y: row.position_y });
-            continue;
+        if (updatesByType.vault.length > 0) {
+          const u_ids = [];
+          const u_pos_xs = [];
+          const u_pos_ys = [];
+          const u_widths = [];
+          const u_heights = [];
+
+          for (const update of updatesByType.vault) {
+            u_ids.push(update.id);
+            u_pos_xs.push(update.position_x);
+            u_pos_ys.push(update.position_y);
+            u_widths.push(update.width ?? null);
+            u_heights.push(update.height ?? null);
           }
 
-          if (type === 'vault') {
-            const result = await client.query(
-              'UPDATE vaults SET position_x = $1, position_y = $2, width = COALESCE($3, width), height = COALESCE($4, height), updated_at = CURRENT_TIMESTAMP WHERE id = $5 AND user_id = $6 RETURNING *',
-              [position_x, position_y, width ?? null, height ?? null, id, req.user.id]
-            );
+          const result = await client.query(`
+            UPDATE vaults AS v
+            SET
+              position_x = u.position_x,
+              position_y = u.position_y,
+              width = COALESCE(u.width, v.width),
+              height = COALESCE(u.height, v.height),
+              updated_at = CURRENT_TIMESTAMP
+            FROM (
+              SELECT * FROM UNNEST(
+                $1::int[], $2::numeric[], $3::numeric[], $4::numeric[], $5::numeric[]
+              ) AS t(id, position_x, position_y, width, height)
+            ) AS u
+            WHERE v.id = u.id AND v.user_id = $6
+            RETURNING v.*
+          `, [u_ids, u_pos_xs, u_pos_ys, u_widths, u_heights, req.user.id]);
 
-            if (result.rows.length === 0) {
-              failed.push({ type, id, error: 'Vault not found' });
-              continue;
+          const foundIds = new Set(result.rows.map(r => r.id));
+
+          for (const update of updatesByType.vault) {
+            if (!foundIds.has(update.id)) {
+              failed.push({ type: 'vault', id: update.id, error: 'Vault not found' });
             }
-
-            const row = result.rows[0];
-            updated.push({ type, id: row.id, position_x: row.position_x, position_y: row.position_y, width: row.width, height: row.height });
-            continue;
           }
 
-          failed.push({ type, id, error: 'Unknown update type' });
+          for (const row of result.rows) {
+            updated.push({ type: 'vault', id: row.id, position_x: row.position_x, position_y: row.position_y, width: row.width, height: row.height });
+          }
         }
       });
 


### PR DESCRIPTION
### 💡 What
Refactored `backend/src/routes/canvas.routes.js` to batch update multiple canvas elements per table. Rather than executing a sequential `for` loop that fires an `UPDATE` query for each individual position change (O(n)), updates are grouped by type (list, note, whiteboard, wireframe, vault). For each group, a single optimized query is executed using PostgreSQL's `UNNEST` syntax, bringing the theoretical time complexity per element type down to O(1) query.

### 🎯 Why
When users interact heavily with their canvas (like dragging or shifting multiple objects simultaneously), the application generated a tsunami of N+1 database updates. This bottleneck creates significant database round-trip latency, connection pool exhaustion risks, and increased CPU usage for query parsing. Batching these requests reduces the load immensely, providing a faster API response and scaling better under concurrency.

### 📊 Measured Improvement
I wrote a micro-benchmark (`backend/benchmark_canvas_notes.js`) comparing the two update strategies using 500 mock element updates:

**Baseline (Sequential Updates)**
- Executes: 500 individual queries
- Penalty: Susceptible to high aggregate network latency and parsing overhead. 

**Refactored Improvement (UNNEST)**
- Executes: 1 query via Array matching
- Effect: Complete elimination of the N+1 loop. 

*Rationale:* The speed improvement in query text generation and JS looping is negligible (~0ms vs ~0ms for 500 items). The massive performance gain happens entirely on the network boundary and the database itself: doing 1 fast parameterized query instead of 500 sequential DB trips.

---
*PR created automatically by Jules for task [15495346152962095231](https://jules.google.com/task/15495346152962095231) started by @codebymv*